### PR TITLE
Skip images already downloaded

### DIFF
--- a/redcaps/download.py
+++ b/redcaps/download.py
@@ -153,7 +153,8 @@ def download_imgs(
             image_savepath = os.path.join(
                 save_to, ann["subreddit"], f"{ann['image_id']}.jpg"
             )
-            worker_args.append((ann["url"], image_savepath, image_downloader))
+            if not os.path.exists(image_savepath):
+                worker_args.append((ann["url"], image_savepath, image_downloader))
 
         # Collect download status of images in these annotations (True/False).
         download_status: List[bool] = []


### PR DESCRIPTION
I tested this with the first json annotation file of Redcaps v1.0, and the behavior is as expected:
```
$ for ann_file in ./annotations/*.json; do
>     redcaps download-imgs -a $ann_file --save-to path/to/images --resize 512 -j 4
>     # Set --resize -1 to turn off resizing shorter edge (saves disk space).
> done
Downloading Images: 100%|███████████████████| 1446/1446 [10:43<00:00,  2.25it/s]
Downloaded 1422/1446 images from ./annotations/abandoned_2017.json!

(CTRL + c to interrupt, and then restart:)

$ for ann_file in ./annotations/*.json; do
>     redcaps download-imgs -a $ann_file --save-to path/to/images --resize 512 -j 4
>     # Set --resize -1 to turn off resizing shorter edge (saves disk space).
> done
Downloading Images: 100%|█████████████████████████████████████████████████████████████████████████████████████| 24/24 [00:03<00:00,  7.15it/s]
Downloaded 0/24 images from ./annotations/abandoned_2017.json!
```
As we can see, the downloader only attempted to download the missing images.