### PR TITLE
Correct `make_tarfiles.py` argument name

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ containing 1000 image-text pairs, skipping instances whose images were missing:
 ```
 for ann in datasets/redcaps/annotations/*.json; do
   python scripts/make_tarfiles.py --input $ann \
-    --images datasets/redcaps/images --output-dir datasets/redcaps/tarfiles
+    --image-dir datasets/redcaps/images --output-dir datasets/redcaps/tarfiles
 done
 ```
 


### PR DESCRIPTION
It's `--image-dir`, not `--images`:
https://github.com/redcaps-dataset/redcaps-downloader/blob/c7d164e57931f08cdc9442b0f9b1fa4e3066548b/scripts/make_tarfiles.py#L19-L23