### PR TITLE
Option to use txt caption files in the tar archive

### DIFF
--- a/scripts/make_tarfiles.py
+++ b/scripts/make_tarfiles.py
@@ -26,6 +26,10 @@ parser.add_argument(
     "-z", "--shard-size", type=int, default=1000,
     help="Path prefix for saving TAR files.",
 )
+parser.add_argument(
+    "--format", choices=["json", "txt"], default="json",
+    help="Format of the caption files.",
+)
 # fmt: on
 
 
@@ -63,13 +67,18 @@ def main(_A: argparse.Namespace):
 
         # Dump annotation JSON to a temporary file to add in TAR.
         with tempfile.NamedTemporaryFile("w+") as tmpfile:
-            add_in_tar = {"subreddit": ann["subreddit"], "caption": ann["caption"]}
-            tmpfile.write(json.dumps(add_in_tar))
+            if _A.format == 'json':
+                add_in_tar = {"subreddit": ann["subreddit"], "caption": ann["caption"]}
+                data = json.dumps(add_in_tar)
+            else:
+                data = ann["caption"]
+
+            tmpfile.write(data)
             tmpfile.seek(0)
 
             # Add image (JPG) and annotation (JSON) in TAR file.
             tar_handle.add(image_path, arcname=f"{ann['image_id']}.jpg")
-            tar_handle.add(tmpfile.name, arcname=f"{ann['image_id']}.json")
+            tar_handle.add(tmpfile.name, arcname=f"{ann['image_id']}.{_A.format}")
 
         ADDED_ANNS += 1
 


### PR DESCRIPTION
Some CLIP implementations, notably [open_clip](https://github.com/mlfoundations/open_clip), expect the caption files to be [just txt files with nothing but captions](https://github.com/mlfoundations/open_clip/blob/5f7892b672b21e6853d0f6c11b18dda9bcf36c8d/tests/test_wds.py#L39-L46). This small PR adds support for such repos.